### PR TITLE
lighttpd-enable-mod returns 2 if already enabled

### DIFF
--- a/definitions/lighttpd_module.rb
+++ b/definitions/lighttpd_module.rb
@@ -25,6 +25,7 @@ define :lighttpd_module, :enable => true do
     code <<-EOH
       #{module_command} #{params[:name]}
     EOH
+    return [0, 2]
     notifies :restart, resources(:service => "lighttpd"), :delayed
   end
 end


### PR DESCRIPTION
After a seconds pass this code would bailout, because the module is already installed. lighttpd-enable-mod returns 2 instead of 0, because it does nothing. At least on current debian wheezy.
